### PR TITLE
internal vector trait structure

### DIFF
--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -231,7 +231,7 @@ cfg_if! {
         pub struct Vector<T> {
             values: Vec<T>,
         }
-        impl<'v, T: 'v> private::VectorType<'v> for Vector<T> {
+        impl<'v, T: 'v> private::VectorType<'v, T> for Vector<T> {
             type Iter = core::slice::Iter<'v, T>;
 
             fn iter(&'v self) -> Self::Iter {
@@ -312,7 +312,7 @@ cfg_if! {
         pub struct MutVector<T> {
             values: Vec<T>,
         }
-        impl<'v, T: 'v> private::VectorType<'v> for MutVector<T> {
+        impl<'v, T: 'v> private::VectorType<'v, T> for MutVector<T> {
             type Iter = core::slice::Iter<'v, T>;
 
             fn iter(&'v self) -> Self::Iter {
@@ -348,7 +348,7 @@ cfg_if! {
         pub struct VectorSlice<'v, T> {
             values: &'v [T]
         }
-        impl<'v, T> private::VectorType<'v> for VectorSlice<'v, T> {
+        impl<'v, T> private::VectorType<'v, T> for VectorSlice<'v, T> {
             type Iter = core::slice::Iter<'v, T>;
 
             fn iter(&'v self) -> Self::Iter {
@@ -380,7 +380,7 @@ cfg_if! {
         pub struct MutVectorSlice<'v, T> {
             values: &'v mut [T]
         }
-        impl<'v, T> private::VectorType<'v> for MutVectorSlice<'v, T> {
+        impl<'v, T> private::VectorType<'v, T> for MutVectorSlice<'v, T> {
             type Iter = core::slice::Iter<'v, T>;
 
             fn iter(&'v self) -> Self::Iter {

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -126,6 +126,40 @@ mod private {
             )
         }
     }
+
+    pub trait MapMut<'v, T>: MutVectorType<'v, T>
+    {
+        fn map_mut<F>(&'v mut self, f: F) -> &'v mut Self
+        where
+            F: FnMut(&'v mut T)
+        {
+            for item in self.iter_mut() {
+
+            }
+            self
+        }
+
+        fn map_index_mut<F>(&'v mut self, f: F) -> &'v mut Self
+        where
+            F: FnMut(usize)
+        {
+            self.iter_mut()
+                .enumerate()
+                .map(|(index, ..)| index)
+                .for_each(f);
+            self
+        }
+
+        fn map_enumerate_mut<F>(&'v mut self, f: F) -> &'v mut Self
+        where
+            F: FnMut(usize, &'v mut T)
+        {
+            self.iter_mut()
+                .enumerate()
+                .for_each(|(index, value)| f(index, value));
+            self
+        }
+    }
 }
 
 cfg_if! {

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -162,9 +162,10 @@ mod private {
 
     pub trait Combine<'v, L>: VectorType<'v, L>
     {
-        fn combine<F, R, O>(&'v self, other: crate::vectors::Vector<R>, f: F) -> crate::vectors::Vector<O>
+        fn combine<F, R, O, I>(&'v self, other: &dyn VectorType<'v, R, Iter = I>, f: F) -> crate::vectors::Vector<O>
         where
-            F: Fn(&L, &R) -> O
+            F: Fn(&L, &R) -> O,
+            I: Iterator<Item = R>
         {
             use alloc::vec::Vec;
 
@@ -180,9 +181,10 @@ mod private {
             crate::vectors::Vector::from(params)
         }
 
-        fn combine_enumerate<F, R, O>(&'v self, other: crate::vectors::Vector<R>, f: F) -> crate::vectors::Vector<O>
+        fn combine_enumerate<F, R, O, I>(&'v self, other: &dyn VectorType<'v, R, Iter = I>, f: F) -> crate::vectors::Vector<O>
         where
-            F: Fn(usize, &L, &R) -> O
+            F: Fn(usize, &L, &R) -> O,
+            I: Iterator<Item = R>
         {
             use alloc::vec::Vec;
 

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -72,6 +72,16 @@ mod private {
 
         fn len(&'v self) -> usize;
     }
+
+    pub trait MutVectorType<'v, T>: VectorType<'v, T>
+    where
+        Self: 'v,
+        Self::IterMut: Iterator<Item = &'v mut T>
+    {
+        type IterMut;
+
+        fn iter_mut(&'v mut self) -> Self::IterMut;
+    }
 }
 
 cfg_if! {

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -82,6 +82,50 @@ mod private {
 
         fn iter_mut(&'v mut self) -> Self::IterMut;
     }
+
+    pub trait Map<'v, I>: VectorType<'v, I>
+    {
+        fn map<F, O>(&'v self, f: F) -> crate::vectors::Vector<O>
+        where
+            F: Fn(&'v I) -> O
+        {
+            use alloc::vec::Vec;
+
+            crate::vectors::Vector::from(
+                self.iter()
+                    .map(|value| f(value))
+                    .collect::<Vec<O>>()
+            )
+        }
+
+        fn map_index<F, O>(&'v self, f: F) -> crate::vectors::Vector<O>
+        where
+            F: Fn(usize) -> O
+        {
+            use alloc::vec::Vec;
+
+            crate::vectors::Vector::from(
+                self.iter()
+                    .enumerate()
+                    .map(|(index, _)| f(index))
+                    .collect::<Vec<O>>()
+            )
+        }
+
+        fn map_enumerate<F, O>(&'v self, f: F) -> crate::vectors::Vector<O>
+        where
+            F: Fn(usize, &'v I) -> O
+        {
+            use alloc::vec::Vec;
+
+            crate::vectors::Vector::from(
+                self.iter()
+                    .enumerate()
+                    .map(|(index, value)| f(index, value))
+                    .collect::<Vec<O>>()
+            )
+        }
+    }
 }
 
 cfg_if! {

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -160,6 +160,46 @@ mod private {
             self
         }
     }
+
+    pub trait Combine<'v, L>: VectorType<'v, L>
+    {
+        fn combine<F, R, O>(&'v self, other: crate::vectors::Vector<R>, f: F) -> crate::vectors::Vector<O>
+        where
+            F: Fn(&L, &R) -> O
+        {
+            use alloc::vec::Vec;
+
+            if self.len() != other.len() {
+                panic!("Cannot map vectors of different sizes")
+            }
+            let mut iter = self.iter().zip(other.iter());
+    
+            let mut params = Vec::with_capacity(self.len());
+            while let Some((lhs_value, rhs_value)) = iter.next() {
+                params.push(f(lhs_value, rhs_value))
+            }
+            crate::vectors::Vector::from(params)
+        }
+
+        fn combine_enumerate<F, R, O>(&'v self, other: crate::vectors::Vector<R>, f: F) -> crate::vectors::Vector<O>
+        where
+            F: Fn(usize, &L, &R) -> O
+        {
+            use alloc::vec::Vec;
+
+            if self.len() != other.len() {
+                panic!("Cannot map vectors of different sizes")
+            }
+    
+            let mut iter = self.iter().zip(other.iter()).enumerate();
+    
+            let mut params = Vec::with_capacity(self.len());
+            while let Some((index, (lhs_value, rhs_value))) = iter.next() {
+                params.push(f(index, lhs_value, rhs_value));
+            }
+            crate::vectors::Vector::from(params)
+        }
+    }
 }
 
 cfg_if! {

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -133,9 +133,8 @@ mod private {
         where
             F: FnMut(&'v mut T)
         {
-            for item in self.iter_mut() {
-
-            }
+            self.iter_mut()
+                .for_each(f);
             self
         }
 

--- a/src/vectors/mod.rs
+++ b/src/vectors/mod.rs
@@ -61,10 +61,10 @@ mod vector_slice;
 mod mut_vector_slice;
 
 mod private {
-    pub trait VectorType<'v>
+    pub trait VectorType<'v, T>
     where
         Self: 'v,
-        Self::Iter: Iterator
+        Self::Iter: Iterator<Item = &'v T>
     {
         type Iter;
 

--- a/src/vectors/mut_vector.rs
+++ b/src/vectors/mut_vector.rs
@@ -1,104 +1,108 @@
 #![cfg(feature = "full")]
+use crate::vectors::{
+    MutVector, Vector, VectorSlice,
+    private::{VectorType, Map, Combine}
+};
+use core::ops::{Index, Range, IndexMut};
 
-use alloc::vec::Vec;
-use crate::vectors::{Vector, MutVector, VectorSlice, MutVectorSlice};
-use core::ops::{Index, IndexMut, Range};
+use crate::vectors::private::{MapMut, CombineMut};
 
 impl<T> MutVector<T> {
     pub fn len(&self) -> usize {
-        self.values.len()
+        <Self as VectorType<T>>::len(&self)
     }
 
-    pub fn as_slice<'v>(&'v self, range: Range<usize>) -> VectorSlice<'v, T> {
+    pub fn as_slice(&self, range: Range<usize>) -> VectorSlice<'_, T> {
         VectorSlice {
-            values: self.values
-                        .as_slice()
-                        .split_at(range.start)
-                        .1
-                        .split_at(range.len())
-                        .0
+            values: self
+                .values
+                .as_slice()
+                .split_at(range.start)
+                .1
+                .split_at(range.len())
+                .0,
         }
     }
 
-    pub fn as_slice_mut<'v>(&'v mut self, range: Range<usize>) -> MutVectorSlice<'v, T> {
-        MutVectorSlice {
-            values: self.values
-                        .as_mut_slice()
-                        .split_at_mut(range.start)
-                        .1
-                        .split_at_mut(range.len())
-                        .0
-        }
+    pub fn map<F, Output>(&self, f: F) -> Vector<Output>
+    where
+        F: Fn(&T) -> Output
+    {
+        <Self as Map<T>>::map(&self, f)
+    }
+
+    pub fn map_index<F, Output>(&self, f: F) -> Vector<Output>
+    where
+        F: Fn(usize) -> Output
+    {
+        <Self as Map<T>>::map_index(&self, f)
+    }
+
+    pub fn map_enumerate<F, Output>(&self, f: F) -> Vector<Output>
+    where
+        F: Fn(usize, &T) -> Output
+    {
+        <Self as Map<T>>::map_enumerate(&self, f)
+    }
+
+    pub fn map_mut<'v, F>(&'v mut self, f: F) -> &'v mut Self
+    where
+        F: Fn(&mut T)
+    {
+        <Self as MapMut<T>>::map_mut(self, f)
+    }
+
+    pub fn map_index_mut<'v, F, Output>(&'v mut self, f: F) -> &'v Self
+    where
+        F: Fn(usize) -> T
+    {
+        <Self as MapMut<T>>::map_index_mut(self, f)
+    }
+
+    pub fn map_enumerate_mut<'v, F, Output>(&'v mut self, f: F) -> &'v Self
+    where
+        F: Fn(usize, &mut T)
+    {
+        <Self as MapMut<T>>::map_enumerate_mut(self, f)
+    }
+
+    pub fn combine<'v, F, Rhs, Output, Iter>(&'v self, other: &'v dyn VectorType<'v, Rhs, Iter = Iter>, f: F) -> crate::vectors::Vector<Output>
+    where
+        F: Fn(&T, &Rhs) -> Output,
+        Iter: Iterator<Item = &'v Rhs>,
+        Rhs: 'v
+    {
+        <Self as Combine<T>>::combine(&self, other, f)
+    }
+
+    pub fn combine_enumerate<'v, F, Rhs, Output, Iter>(&'v self, other: &'v dyn VectorType<'v, Rhs, Iter = Iter>, f: F) -> crate::vectors::Vector<Output>
+    where
+        F: Fn(usize, &T, &Rhs) -> Output,
+        Iter: Iterator<Item = &'v Rhs>,
+        Rhs: 'v
+    {
+        <Self as Combine<T>>::combine_enumerate(&self, other, f)
+    }
+
+    pub fn combine_mut<'v, F, Rhs, Iter>(&'v mut self, other: &'v dyn VectorType<'v, Rhs, Iter = Iter>, f: F) -> &'v mut Self
+    where
+        F: Fn(&mut T, &Rhs),
+        Iter: Iterator<Item = &'v Rhs>,
+        Rhs: 'v
+    {
+        <Self as CombineMut<T>>::combine_mut(self, other, f)
+    }
+
+    pub fn combine_enumerate_mut<'v, F, Rhs, Iter>(&'v mut self, other: &'v dyn VectorType<'v, Rhs, Iter = Iter>, f: F) -> &'v mut Self
+    where
+        F: Fn(usize, &mut T, &Rhs),
+        Iter: Iterator<Item = &'v Rhs>,
+        Rhs: 'v
+    {
+        <Self as CombineMut<T>>::combine_enumerate_mut(self, other, f)
     }
 }
-impl<T> MutVector<T> {
-    pub fn lambda_mut<'v, F>(&'v mut self, f: F) -> &'v mut Self
-    where
-        F: Fn(&mut T) {
-        self.values.iter_mut().for_each(|value| f(value));
-        self
-    }
-
-    pub fn lambda_index_mut<'v, F>(&'v mut self, f: F) -> &'v mut Self
-    where
-        F: Fn(usize) {
-        self.values.iter_mut().enumerate().for_each(|(index, _)| f(index));
-        self
-    }
-
-    pub fn lambda_enumerate_mut<'v, F>(&'v mut self, f: F) -> &'v mut Self
-    where
-        F: Fn(usize, &mut T) {
-        self.values.iter_mut().enumerate().for_each(|(index, value)| f(index, value));
-        self
-    }
-}
-impl<T> MutVector<T> {
-    pub fn lambda<F>(&self, f: F) -> Vector<T>
-    where
-        F: Fn(&T) -> T {
-        Vector::from(
-            self.values
-                .iter()
-                .map(|value| f(value))
-                .collect::<Vec<T>>()
-        )
-    }
-
-    pub fn lambda_index<F>(&self, f: F) -> Vector<T>
-    where
-        F: Fn(usize) -> T {
-        Vector::from(
-            self.values
-                .iter()
-                .enumerate()
-                .map(|(index, _)| f(index))
-                .collect::<Vec<T>>()
-        )
-    }
-
-    pub fn lambda_enumerate<F>(&self, f: F) -> Vector<T>
-    where
-        F: Fn(usize, &T) -> T {
-            Vector::from(
-                self.values
-                    .iter()
-                    .enumerate()
-                    .map(|(index, value)| f(index, value))
-                    .collect::<Vec<T>>()
-            )
-    }
-}
-
-impl<T, U> From<U> for MutVector<T>
-where
-    U: Into<Vec<T>>
-{
-    fn from(values: U) -> Self {
-        MutVector { values: values.into() }
-    }
-}
-impl<'v, T> Index<usize> for MutVector<T>
+impl<T> Index<usize> for MutVector<T>
 where
     T: Clone,
 {
@@ -108,7 +112,7 @@ where
         &self.values[index]
     }
 }
-impl<'v, T> IndexMut<usize> for MutVector<T>
+impl<T> IndexMut<usize> for MutVector<T>
 where
     T: Clone,
 {

--- a/src/vectors/mut_vector_slice.rs
+++ b/src/vectors/mut_vector_slice.rs
@@ -1,113 +1,126 @@
-mod no_std {
-    #![cfg(feature = "no_std")]
-    
-    use core::ops::{Range, Index, IndexMut};
-    use crate::vectors::{VectorSlice, MutVectorSlice};
+use cfg_if::cfg_if;
 
-    impl<'v, T> MutVectorSlice<'v, T> {
-        pub fn len(&self) -> usize {
-            self.values.len()
-        }
-
-        pub fn as_slice(&'v self, range: Range<usize>) -> VectorSlice<'v, T> {
-            VectorSlice {
-                values: self.values
-                            .split_at(range.start).1
-                            .split_at(range.len()).0
+cfg_if!{
+    if #[cfg(feature = "full")] {
+        use crate::vectors::{
+            MutVectorSlice, Vector, VectorSlice,
+            private::{VectorType, Map, Combine}
+        };
+        use core::ops::{Index, Range, IndexMut};
+        
+        use super::private::{MapMut, CombineMut};
+        
+        impl<'v, T> MutVectorSlice<'v, T> {
+            pub fn len(&self) -> usize {
+                <Self as VectorType<T>>::len(&self)
+            }
+        
+            pub fn as_slice(&self, range: Range<usize>) -> VectorSlice<'_, T> {
+                VectorSlice {
+                    values: self
+                        .values
+                        .split_at(range.start)
+                        .1
+                        .split_at(range.len())
+                        .0,
+                }
+            }
+        
+            pub fn map<F, Output>(&'v self, f: F) -> Vector<Output>
+            where
+                F: Fn(&T) -> Output
+            {
+                <Self as Map<T>>::map(&self, f)
+            }
+        
+            pub fn map_index<F, Output>(&'v self, f: F) -> Vector<Output>
+            where
+                F: Fn(usize) -> Output
+            {
+                <Self as Map<T>>::map_index(&self, f)
+            }
+        
+            pub fn map_enumerate<F, Output>(&'v self, f: F) -> Vector<Output>
+            where
+                F: Fn(usize, &T) -> Output
+            {
+                <Self as Map<T>>::map_enumerate(&self, f)
+            }
+        
+            pub fn map_mut<F>(&'v mut self, f: F) -> &'v mut Self
+            where
+                F: Fn(&mut T)
+            {
+                <Self as MapMut<T>>::map_mut(self, f)
+            }
+        
+            pub fn map_index_mut<F, Output>(&'v mut self, f: F) -> &'v Self
+            where
+                F: Fn(usize) -> T
+            {
+                <Self as MapMut<T>>::map_index_mut(self, f)
+            }
+        
+            pub fn map_enumerate_mut<F, Output>(&'v mut self, f: F) -> &'v Self
+            where
+                F: Fn(usize, &mut T)
+            {
+                <Self as MapMut<T>>::map_enumerate_mut(self, f)
+            }
+        
+            pub fn combine<F, Rhs, Output, Iter>(&'v self, other: &'v dyn VectorType<'v, Rhs, Iter = Iter>, f: F) -> crate::vectors::Vector<Output>
+            where
+                F: Fn(&T, &Rhs) -> Output,
+                Iter: Iterator<Item = &'v Rhs>,
+                Rhs: 'v
+            {
+                <Self as Combine<T>>::combine(&self, other, f)
+            }
+        
+            pub fn combine_enumerate<F, Rhs, Output, Iter>(&'v self, other: &'v dyn VectorType<'v, Rhs, Iter = Iter>, f: F) -> crate::vectors::Vector<Output>
+            where
+                F: Fn(usize, &T, &Rhs) -> Output,
+                Iter: Iterator<Item = &'v Rhs>,
+                Rhs: 'v
+            {
+                <Self as Combine<T>>::combine_enumerate(&self, other, f)
+            }
+        
+            pub fn combine_mut<F, Rhs, Iter>(&'v mut self, other: &'v dyn VectorType<'v, Rhs, Iter = Iter>, f: F) -> &'v mut Self
+            where
+                F: Fn(&mut T, &Rhs),
+                Iter: Iterator<Item = &'v Rhs>,
+                Rhs: 'v
+            {
+                <Self as CombineMut<T>>::combine_mut(self, other, f)
+            }
+        
+            pub fn combine_enumerate_mut<F, Rhs, Iter>(&'v mut self, other: &'v dyn VectorType<'v, Rhs, Iter = Iter>, f: F) -> &'v mut Self
+            where
+                F: Fn(usize, &mut T, &Rhs),
+                Iter: Iterator<Item = &'v Rhs>,
+                Rhs: 'v
+            {
+                <Self as CombineMut<T>>::combine_enumerate_mut(self, other, f)
             }
         }
     }
+}
+impl<'v, T> Index<usize> for MutVectorSlice<'v, T>
+where
+    T: Clone,
+{
+    type Output = T;
 
-    impl<'v, T> MutVectorSlice<'v, T> {
-        pub fn lambda_mut<F>(&'v mut self, f: F) -> &'v mut Self
-        where
-            F: Fn(&mut T) {
-            self.values.iter_mut().for_each(|value| f(value));
-            self
-        }
-
-        pub fn lambda_index_mut<F>(&'v mut self, f: F) -> &'v mut Self
-        where
-            F: Fn(usize) {
-            self.values.iter_mut().enumerate().for_each(|(index, _)| f(index));
-            self
-        }
-
-        pub fn lambda_enumerate_mut<F>(&'v mut self, f: F) -> &'v mut Self
-        where
-            F: Fn(usize, &mut T) {
-            self.values.iter_mut().enumerate().for_each(|(index, value)| f(index, value));
-            self
-        }
-    }
-
-    impl<'v, T, U> From<U> for MutVectorSlice<'v, T>
-    where
-        U: Into<&'v mut [T]>
-    {
-        fn from(values: U) -> Self {
-            MutVectorSlice { values: values.into() }
-        }
-    }
-    impl<'v, T> Index<usize> for MutVectorSlice<'v, T>
-    where
-        T: Clone {
-        type Output = T;
-
-        fn index(&self, index: usize) -> &Self::Output {
-            &self.values[index]
-        }
-    }
-    impl<'v, T> IndexMut<usize> for MutVectorSlice<'v, T>
-    where
-        T: Clone,
-    {
-        fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-            &mut self.values[index]
-        }
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.values[index]
     }
 }
-
-mod full {
-    #![cfg(feature = "full")]
-
-    use alloc::vec::Vec;
-    use crate::vectors::{Vector, MutVectorSlice};
-
-    impl<'v, T> MutVectorSlice<'v, T> {
-        pub fn lambda<F>(&self, f: F) -> Vector<T>
-        where
-            F: Fn(&T) -> T {
-            Vector::from(
-                self.values
-                    .iter()
-                    .map(|value| f(value))
-                    .collect::<Vec<T>>()
-            )
-        }
-
-        pub fn lambda_index<F>(&self, f: F) -> Vector<T>
-        where
-            F: Fn(usize) -> T {
-            Vector::from(
-                self.values
-                    .iter()
-                    .enumerate()
-                    .map(|(index, _)| f(index))
-                    .collect::<Vec<T>>()
-            )
-        }
-
-        pub fn lambda_enumerate<F>(&self, f: F) -> Vector<T>
-        where
-            F: Fn(usize, &T) -> T {
-                Vector::from(
-                    self.values
-                        .iter()
-                        .enumerate()
-                        .map(|(index, value)| f(index, value))
-                        .collect::<Vec<T>>()
-                )
-        }
+impl<'v, T> IndexMut<usize> for MutVectorSlice<'v, T>
+where
+    T: Clone,
+{
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.values[index]
     }
 }

--- a/src/vectors/vector.rs
+++ b/src/vectors/vector.rs
@@ -2,7 +2,7 @@
 
 use crate::vectors::{
     MutVector, MutVectorSlice, Vector, VectorSlice,
-    private::VectorType
+    private::{VectorType, Map, Combine}
 };
 use core::ops::{Index, Range};
 use alloc::vec::Vec;
@@ -11,7 +11,7 @@ use cfg_if::cfg_if;
 impl<T> Vector<T> {
     /// Returns the length of the `Vector<T>`.
     pub fn len(&self) -> usize {
-        self.values.len()
+        <Self as VectorType<T>>::len(&self)
     }
 
     /// Cheaply creates a sliced view of a `Vector<T>` instance.
@@ -34,7 +34,7 @@ impl<T> Vector<T> {
     /// assert_eq!(vector![1, 2], lhs_view.into());
     /// assert_eq!(vector![3, 4], rhs_view.into())
     /// ```
-    pub fn as_slice<'v>(&'v self, range: Range<usize>) -> VectorSlice<'v, T> {
+    pub fn as_slice(&self, range: Range<usize>) -> VectorSlice<'_, T> {
         VectorSlice {
             values: self
                 .values
@@ -45,116 +45,44 @@ impl<T> Vector<T> {
                 .0,
         }
     }
-}
 
-/// # Map Implementations
-///
-/// Applies a function element-wise to every value in the
-/// vector to produce a new vector.
-///
-/// Internally, this is simply using the `map()` method from
-/// the `Iterator` trait.
-///
-/// ## `.map()` Example
-/// 
-/// ```rust
-/// use adv_linalg_lib::vector;
-/// use adv_linalg_lib::vectors::Vector;
-///
-/// let vector1 = vector![1, 2, 3];
-/// let vector2 = vector1.map(|val| val - 1);
-/// 
-/// assert_eq!(vector2, vector![0, 1, 2])
-/// ```
-///
-/// ## Panic!
-///
-/// This function will panic if the vectors are two different sizes.
-impl<I> Vector<I> {
-    pub fn map<F, O>(&self, f: F) -> Vector<O>
+    pub fn map<F, Output>(&self, f: F) -> Vector<Output>
     where
-        F: Fn(&I) -> O,
+        F: Fn(&T) -> Output
     {
-        Vector::from(self.values.iter().map(|value| f(value)).collect::<Vec<O>>())
+        <Self as Map<T>>::map(&self, f)
     }
 
-    pub fn map_index<F, O>(&self, f: F) -> Vector<O>
+    pub fn map_index<F, Output>(&self, f: F) -> Vector<Output>
     where
-        F: Fn(usize) -> O,
+        F: Fn(usize) -> Output
     {
-        Vector::from(
-            self.values
-                .iter()
-                .enumerate()
-                .map(|(index, _)| f(index))
-                .collect::<Vec<O>>(),
-        )
+        <Self as Map<T>>::map_index(&self, f)
     }
 
-    pub fn map_enumerate<F, O>(&self, f: F) -> Vector<O>
+    pub fn map_enumerate<F, Output>(&self, f: F) -> Vector<Output>
     where
-        F: Fn(usize, &I) -> O,
+        F: Fn(usize, &T) -> Output
     {
-        Vector::from(
-            self.values
-                .iter()
-                .enumerate()
-                .map(|(index, value)| f(index, value))
-                .collect::<Vec<O>>(),
-        )
-    }
-}
-
-/// # Combine Implementations
-///
-/// Applies a function pair-wise between two vectors that produces a new vector.
-///
-/// ## `.combine()` Example
-/// ```rust
-/// use adv_linalg_lib::vector;
-/// use adv_linalg_lib::vectors::Vector;
-///
-/// let vector1 = vector![1, 2, 3];
-/// let vector2 = vector![30, 15, 10];
-/// 
-/// let combined = vector1.combine(&vector2, |lhs, rhs| lhs * rhs);
-/// assert_eq!(combined, vector![30, 30, 30])
-/// ```
-/// ## Panic!
-/// 
-/// This function will panic if the vectors are two different sizes.
-impl<'v, L> Vector<L> {
-    pub fn combine<F, R, O>(&self, other: &'v dyn VectorType<'v, Iter = core::slice::Iter<'v, R>>, f: F) -> Vector<O>
-    where
-        F: Fn(&L, &R) -> O,
-    {
-        if self.len() != other.len() {
-            panic!("Cannot map vectors of different sizes")
-        }
-        let mut iter = self.iter().zip(other.iter());
-
-        let mut params = Vec::with_capacity(self.len());
-        while let Some((lhs_value, rhs_value)) = iter.next() {
-            params.push(f(lhs_value, rhs_value))
-        }
-        Vector::from(params)
+        <Self as Map<T>>::map_enumerate(&self, f)
     }
 
-    pub fn combine_enumerate<F, R, O>(&self, other: &'v dyn VectorType<'v, Iter = core::slice::Iter<'v, R>>, f: F) -> Vector<O>
+    pub fn combine<'v, F, Rhs, Output, Iter>(&'v self, other: &'v dyn VectorType<'v, Rhs, Iter = Iter>, f: F) -> crate::vectors::Vector<Output>
     where
-        F: Fn(&L, &R, usize) -> O,
+        F: Fn(&T, &Rhs) -> Output,
+        Iter: Iterator<Item = &'v Rhs>,
+        Rhs: 'v
     {
-        if self.len() != other.len() {
-            panic!("Cannot map vectors of different sizes")
-        }
+        <Self as Combine<T>>::combine(&self, other, f)
+    }
 
-        let mut iter = self.iter().zip(other.iter()).enumerate();
-
-        let mut params = Vec::with_capacity(self.len());
-        while let Some((index, (lhs_value, rhs_value))) = iter.next() {
-            params.push(f(lhs_value, rhs_value, index));
-        }
-        Vector { values: params }
+    pub fn combine_enumerate<'v, F, Rhs, Output, Iter>(&'v self, other: &'v dyn VectorType<'v, Rhs, Iter = Iter>, f: F) -> crate::vectors::Vector<Output>
+    where
+        F: Fn(usize, &T, &Rhs) -> Output,
+        Iter: Iterator<Item = &'v Rhs>,
+        Rhs: 'v
+    {
+        <Self as Combine<T>>::combine_enumerate(&self, other, f)
     }
 }
 


### PR DESCRIPTION
# Concept
This pull request focuses on the complete trait structure for "vector types".

# Goals
This will finally define what being a "vector" is by the following traits:
- `VectorType<'v, T>`: definition of being an internally-immutable vector
- `MutVectorType<'v, T>`: definition of being a internally-mutable vector

From this, shared functionality can be derived:
### Mapping Functionality
#### Immutable
- `Map<'v, Input>`: `VectorType<Input>` produces the type of `VectorType<Output>` from a user defined function `f`...
  - `.map(f: Fn(&Input) -> Output)`: iterates over the elements of the vector
  - `.map_index(f: Fn(usize) -> Output)`: iterates over the ordered indexes of the vector (useful for easy weighting)
  - `.map_enumerate(f: Fn(usize, &Input) -> Output)`: iterates over both the index of the element, and the element itself
#### Mutable
- `MapMut<'v, T>`: `MutVectorType<T>`  mutates each item in the vector from a user defined function `f` ...
  - `.map_mut(f: FnMut(&mut T))`: iterates over the elements of the vector
  - `.map_index_mut(f: Fn(usize))`: iterates over the ordered indexes of the vector (useful for easy weighting)
  - `.map_enumerate_mut(f: FnMut(usize, &mut T))`: iterates over both the index of the element, and the element itself

### Combinator Functionality
#### Immutable
- `Combine<'v, Lhs>`: combines two vectors together from a user defined function `f`...
  - `.combine(other: &VectorType<Rhs>, f: Fn(&Lhs, &Rhs) -> Output)`: iterates over the elements of the lhs vector and rhs vector
  - `.combine_enumerate(other: &VectorType<Rhs>, f: Fn(usize, &Lhs, &Rhs))`: iterates over both the index of the element-pair, and the element-pair itself
#### Mutable
- `CombineMut<'v, T>`:  combines two vectors together and places the results into the lhs vector from a user defined function f ...
  - `.combine_mut(other: &VectorType<Rhs>, f: FnMut(&mut Lhs, &Rhs))`: iterates over the elements of the lhs vector and rhs vector
  - `.combine_enumerate_mut(other: &VectorType<Rhs>, f: FnMut(usize, &mut Lhs, &Rhs))`: iterates over both the index of the element-pair, and the element-pair itself

*notice that the there is one less method, as `combine_index` would functionality be the same as `map_index`*